### PR TITLE
Fix didsorder API methods

### DIFF
--- a/voipms/entities/didsset.py
+++ b/voipms/entities/didsset.py
@@ -221,7 +221,7 @@ class DidsSet(BaseApi):
 
         return self._voipms_client._get(method, parameters)
 
-    def did_info(self, did, routing, pop, dialtime, cnam, billing_type, **kwargs):
+    def did_info(self, did, routing, pop, dialtime, cnam, **kwargs):
         """
         Updates the information from a specific DID
 
@@ -235,11 +235,11 @@ class DidsSet(BaseApi):
         :type dialtime: :py:class:`int`
         :param cnam: [Required] CNAM for the DID (Boolean: True/False)
         :type cnam: :py:class:`bool`
-        :param billing_type: [Required] Billing type for the DID (1 = Per Minute, 2 = Flat)
-        :type billing_type: :py:class:`int`
         :param **kwargs: All optional parameters
         :type **kwargs: :py:class:`dict`
 
+        :param billing_type: Billing type for the DID (1 = Per Minute, 2 = Flat)
+        :type billing_type: :py:class:`int`
         :param failover_busy: Busy Routing for the DID
         :type failover_busy: :py:class:`str`
         :param failover_unreachable: Unreachable Routing for the DID
@@ -297,7 +297,6 @@ class DidsSet(BaseApi):
             "pop": pop,
             "dialtime": dialtime,
             "cnam": cnam,
-            "billing_type": billing_type,
         })
 
         return self._voipms_client._get(method, kwargs)

--- a/voipms/entities/didsset.py
+++ b/voipms/entities/didsset.py
@@ -300,7 +300,7 @@ class DidsSet(BaseApi):
             "billing_type": billing_type,
         })
 
-        return self._order(**kwargs)
+        return self._voipms_client._get(method, kwargs)
 
     def did_pop(self, did, pop):
         """

--- a/voipms/voipmsclient.py
+++ b/voipms/voipmsclient.py
@@ -47,6 +47,12 @@ class VoipMsClient(object):
         :type parameters: :py:class:`str`
         :returns: The JSON output from the API
         """
+
+        # The `method` param can be passed in as a tuple containing both 
+        # params - unpack in that case.
+        if isinstance(method, tuple):
+            method, parameters = method
+
         query_set = {
             "method": method
         }


### PR DESCRIPTION
All the `didsorder` methods fail because they expect to call `VoipMsClient._get()` with a tuple instead of individual `method` and `parameters` params. This fixes them by making `_get()` smarter to allow this scenario.