### PR TITLE
Small fixes - fix unknown escape, rename endoint to endpoint, add make .PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build
+.PHONY: init clean build test deploy
 
 init:
 	pipenv install --dev

--- a/voipms/baseapi.py
+++ b/voipms/baseapi.py
@@ -1,3 +1,6 @@
+from warnings import deprecated
+
+
 class BaseApi(object):
     """
     Simple class to buid path for entities
@@ -11,3 +14,13 @@ class BaseApi(object):
         """
         super(BaseApi, self).__init__()
         self._voipms_client = voipms_client
+
+    @property
+    @deprecated('endoint renamed to endpoint')
+    def endoint(self):
+        return self.endpoint
+
+    @endoint.setter
+    @deprecated('endoint renamed to endpoint')
+    def endoint(self, value):
+        self.endpoint = value

--- a/voipms/entities/accounts.py
+++ b/voipms/entities/accounts.py
@@ -18,7 +18,7 @@ class Accounts(BaseApi):
         Initialize the endpoint
         """
         super(Accounts, self).__init__(*args, **kwargs)
-        self.endoint = 'accounts'
+        self.endpoint = 'accounts'
         self.add = AccountsAdd(self)
         self.create = AccountsCreate(self)
         self.delete = AccountsDelete(self)

--- a/voipms/entities/calls.py
+++ b/voipms/entities/calls.py
@@ -17,7 +17,7 @@ class Calls(BaseApi):
         Initialize the endpoint
         """
         super(Calls, self).__init__(*args, **kwargs)
-        self.endoint = 'calls'
+        self.endpoint = 'calls'
         self.delete = CallsDelete(self)
         self.get = CallsGet(self)
         self.send = CallsSend(self)

--- a/voipms/entities/clients.py
+++ b/voipms/entities/clients.py
@@ -16,7 +16,7 @@ class Clients(BaseApi):
         Initialize the endpoint
         """
         super(Clients, self).__init__(*args, **kwargs)
-        self.endoint = 'clients'
+        self.endpoint = 'clients'
         self.add = ClientsAdd(self)
         self.get = ClientsGet(self)
         self.set = ClientsSet(self)

--- a/voipms/entities/dids.py
+++ b/voipms/entities/dids.py
@@ -24,7 +24,7 @@ class Dids(BaseApi):
         Initialize the endpoint
         """
         super(Dids, self).__init__(*args, **kwargs)
-        self.endoint = 'dids'
+        self.endpoint = 'dids'
         self.back_order = DidsBackOrder(self)
         self.cancel = DidsCancel(self)
         self.connect = DidsConnect(self)

--- a/voipms/entities/e911.py
+++ b/voipms/entities/e911.py
@@ -13,7 +13,7 @@ class E911(BaseApi):
         Initialize the endpoint
         """
         super(E911, self).__init__(*args, **kwargs)
-        self.endoint = 'e911'
+        self.endpoint = 'e911'
 
     def address_types(self, address_type=None):
         """

--- a/voipms/entities/fax.py
+++ b/voipms/entities/fax.py
@@ -24,7 +24,7 @@ class Fax(BaseApi):
         Initialize the endpoint
         """
         super(Fax, self).__init__(*args, **kwargs)
-        self.endoint = 'fax'
+        self.endpoint = 'fax'
         self.cancel = FaxCancel(self)
         self.connect = FaxConnect(self)
         self.delete = FaxDelete(self)

--- a/voipms/entities/general.py
+++ b/voipms/entities/general.py
@@ -14,5 +14,5 @@ class General(BaseApi):
         Initialize the endpoint
         """
         super(General, self).__init__(*args, **kwargs)
-        self.endoint = 'general'
+        self.endpoint = 'general'
         self.get = GeneralGet(self)

--- a/voipms/entities/lnp.py
+++ b/voipms/entities/lnp.py
@@ -15,6 +15,6 @@ class LNP(BaseApi):
         Initialize the endpoint
         """
         super(LNP, self).__init__(*args, **kwargs)
-        self.endoint = 'lnp'
+        self.endpoint = 'lnp'
         self.add = LNPAdd(self)
         self.get = LNPGet(self)

--- a/voipms/entities/voicemail.py
+++ b/voipms/entities/voicemail.py
@@ -20,7 +20,7 @@ class Voicemail(BaseApi):
         Initialize the endpoint
         """
         super(Voicemail, self).__init__(*args, **kwargs)
-        self.endoint = 'voicemail'
+        self.endpoint = 'voicemail'
         self.create = VoicemailCreate(self)
         self.delete = VoicemailDelete(self)
         self.get = VoicemailGet(self)

--- a/voipms/helpers.py
+++ b/voipms/helpers.py
@@ -19,8 +19,13 @@ def validate_date(date_text):
     return date_object
 
 
+EMAIL_RE = re.compile(
+    r'^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$'
+)
+
+
 def validate_email(email):
-    match = re.match('^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$', email)
+    match = re.match(EMAIL_RE, email)
     if match:
         return True
     else:


### PR DESCRIPTION
- `endoint` is a typo, so I created a property called `endoint` pointing to `endpoint`, marked `endoint` as deprecated, and updated all references to the new `endpoint` attribute.
- some missing .PHONY make targets added to .PHONY
- Fix a SyntaxWarning fired when constructing a `VoipMs()` instance.